### PR TITLE
Add CommandToolBuilder

### DIFF
--- a/janis_core/__init__.py
+++ b/janis_core/__init__.py
@@ -32,7 +32,13 @@ from janis_core.registry.shed import JanisShed
 import janis_core.registry.entrypoints as entrypoints
 from janis_core.utils.scatter import ScatterDescription, ScatterMethods
 from janis_core.hints import CaptureType, Engine, HINTS, Hint, HintEnum, HintArray
-from janis_core.tool.commandtool import CommandTool, ToolArgument, ToolInput, ToolOutput
+from janis_core.tool.commandtool import (
+    CommandTool,
+    CommandToolBuilder,
+    ToolArgument,
+    ToolInput,
+    ToolOutput,
+)
 from janis_core.tool.tool import Tool, ToolTypes
 from janis_core.translations import SupportedTranslations
 from janis_core.types import (

--- a/janis_core/__meta__.py
+++ b/janis_core/__meta__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.7.8"
+__version__ = "v0.8.0"
 
 GITHUB_URL = "https://github.com/PMCC-BioinformaticsCore/janis"
 DOCS_URL = "https://janis.readthedocs.io/en/latest/"

--- a/janis_core/tool/commandtool.py
+++ b/janis_core/tool/commandtool.py
@@ -341,6 +341,7 @@ class CommandTool(Tool, ABC):
     def help(self):
         import inspect
 
+        tb = " " * 4
         path = inspect.getfile(self.__class__)
 
         ins = sorted(
@@ -382,12 +383,12 @@ class CommandTool(Tool, ABC):
                     else t.prefix
                 )
             return (
-                f"\t\t{t.tag} ({prefix_with_space}{t.input_type.id()}{('=' + str(t.default)) if t.default is not None else ''})"
+                f"{2 * tb}{t.tag} ({prefix_with_space}{t.input_type.id()}{('=' + str(t.default)) if t.default is not None else ''})"
                 f": {'' if t.doc is None else t.doc}"
             )
 
         output_format = (
-            lambda t: f"\t\t{t.tag} ({t.output_type.id()}): {'' if t.doc is None else t.doc}"
+            lambda t: f"{2 * tb}{t.tag} ({t.output_type.id()}): {'' if t.doc is None else t.doc}"
         )
 
         requiredInputs = "\n".join(

--- a/janis_core/tool/tool.py
+++ b/janis_core/tool/tool.py
@@ -70,12 +70,10 @@ class Tool(ABC, object):
     def id(self) -> str:
         raise Exception("Must implement id() method")
 
-    @staticmethod
-    def tool_module():
+    def tool_module(self):
         return None
 
-    @staticmethod
-    def tool_provider():
+    def tool_provider(self):
         return None
 
     @abstractmethod
@@ -114,9 +112,8 @@ class Tool(ABC, object):
         self.connections = connections
         return self
 
-    @staticmethod
     @abstractmethod
-    def version():
+    def version(self):
         return None
 
     def doc(self) -> Optional[str]:

--- a/janis_core/tool/tool.py
+++ b/janis_core/tool/tool.py
@@ -133,3 +133,52 @@ class Tool(ABC, object):
         :return:
         """
         return self.metadata
+
+    def help(self):
+        import inspect
+
+        tb = " " * 4
+
+        path = inspect.getfile(self.__class__)
+
+        ins = self.tool_inputs()
+
+        metadata = self.metadata
+
+        def input_format(t: TInput):
+            return (
+                f"{2 * tb}{t.id()} ({t.intype.id()}{('=' + str(t.default)) if t.default is not None else ''})"
+                f": {'' if t.doc is None else t.doc}"
+            )
+
+        output_format = (
+            lambda t: f"{2 * tb}{t.id()} ({t.outtype.id()}): {'' if t.doc is None else t.doc}"
+        )
+
+        requiredInputs = "\n".join(
+            input_format(x) for x in ins if not x.intype.optional
+        )
+        optionalInputs = "\n".join(input_format(x) for x in ins if x.intype.optional)
+        outputs = "\n".join(output_format(o) for o in self.tool_outputs())
+
+        return f"""
+Pipeline tool: {path} ({self.id()})
+NAME
+    {self.id()} ({self.friendly_name()})
+
+DOCUMENTATION URL
+    {metadata.documentationUrl if metadata.documentationUrl else "No url provided"}
+
+DESCRIPTION
+    {metadata.documentation if metadata.documentation else "No documentation provided"}
+
+INPUTS:
+    REQUIRED:
+{requiredInputs}
+
+    OPTIONAL:
+{optionalInputs}
+
+OUTPUTS:
+{outputs}
+"""


### PR DESCRIPTION
Tutorial 2 (Command Tool) will result in the following tool:

```python
import janis_core as j
from janis.data_types import Bam

SamToolsFlagstat_1_9 = j.CommandToolBuilder(
    tool="samtoolsflagstat",
    base_command=["samtools", "flagstat"],
    inputs=[
        # 1. Positional bam input
        j.ToolInput("bam", Bam, position=1),
        # 2. `threads` inputs
        j.ToolInput("threads", j.Int(optional=True), prefix="--threads"),
    ],
    outputs=[j.ToolOutput("stats", j.Stdout)],
    container="quay.io/biocontainers/samtools:1.9--h8571acd_11",
    version="v1.9.0",
)
```