### PR TITLE
Replace pkg_resources with importlib_metadata

### DIFF
--- a/janis_core/registry/shed.py
+++ b/janis_core/registry/shed.py
@@ -1,5 +1,4 @@
 from typing import List, Type, Optional
-import pkg_resources, sys
 from inspect import isfunction, ismodule, isabstract, isclass
 
 from janis_core.tool.commandtool import Tool, ToolTypes, CommandTool, CommandToolBuilder
@@ -106,8 +105,10 @@ class JanisShed:
 
     @staticmethod
     def _get_datatype_entrypoints():
+        import importlib_metadata
+
         ep = []
-        eps = pkg_resources.iter_entry_points(group=EP.DATATYPES)
+        eps = importlib_metadata.entry_points().get(EP.DATATYPES, [])
         for entrypoint in eps:
             try:
                 m = entrypoint.load()
@@ -120,8 +121,10 @@ class JanisShed:
 
     @staticmethod
     def _get_tool_entrypoints():
+        import importlib_metadata
+
         ep = []
-        eps = pkg_resources.iter_entry_points(group=EP.TOOLS)
+        eps = importlib_metadata.entry_points().get(EP.TOOLS, [])
         for entrypoint in eps:
             try:
                 m = entrypoint.load()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+importlib-metadata
 cwlgen>=0.4.0
 illusional.wdlgen>=0.2.7
 networkx>=2.1

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     packages=["janis_core"]
     + ["janis_core." + p for p in sorted(find_packages("./janis_core"))],
     install_requires=[
+        "importlib-metadata",
         "cwlgen >= 0.4.0",
         "illusional.wdlgen >= 0.2.7",
         "ruamel.yaml",


### PR DESCRIPTION
Hopefully this will address some slowness from running Janis on the cluster. Based on information found:

- https://coldfix.de/2017/02/25/slow-entrypoints/
- https://github.com/pypa/setuptools/issues/510

Similar fixes to address the other corresponding janis packages. 