### PR TITLE
Remove 'template' from PythonTool illegal keyword list

### DIFF
--- a/janis_core/code/pythontool.py
+++ b/janis_core/code/pythontool.py
@@ -23,7 +23,7 @@ from janis_core.types import (
     all_types,
 )
 
-inspect_ignore_keys = {"self", "args", "kwargs", "cls", "template"}
+inspect_ignore_keys = {"self", "args", "kwargs", "cls"}
 
 
 class PythonTool(CodeTool, ABC):


### PR DESCRIPTION
Closes #9 

This was a copy-paste error when using a similar mechanic when parsing janis-assistant templates. `template` should not be a reserved keyword. As the remainder of the list are all python keywords, I won't implement an actual check yet.