### PR TITLE
Inputvalue coercion

### DIFF
--- a/janis_core/tests/test_validateinputvalue.py
+++ b/janis_core/tests/test_validateinputvalue.py
@@ -37,7 +37,7 @@ class TestValidateInputvalue(unittest.TestCase):
         )
 
     def test_array_invalid_int_string(self):
-        self.assertFalse(Array(String()).validate_value(["aa", 2], True))
+        self.assertTrue(Array(String()).validate_value(["aa", 2], True))
 
     def test_int_invalid_float(self):
         self.assertFalse(Array(Int()).validate_value(2.0, True))

--- a/janis_core/types/common_data_types.py
+++ b/janis_core/types/common_data_types.py
@@ -47,7 +47,10 @@ class String(DataType):
     def validate_value(self, meta: Any, allow_null_if_not_optional: bool):
         if meta is None:
             return self.optional or allow_null_if_not_optional
-        return isinstance(meta, str)
+        return isinstance(meta, (str, float, int))
+
+    def coerce_value_if_possible(self, value):
+        return str(value)
 
     def invalid_value_hint(self, meta):
         if meta is None:
@@ -167,6 +170,12 @@ class Int(DataType):
             return self.optional or allow_null_if_not_optional
         return isinstance(meta, int)
 
+    def coerce_value_if_possible(self, value):
+        try:
+            return int(value)
+        except:
+            raise Exception(f"Value '{value}' cannot be coerced to an integer")
+
     def invalid_value_hint(self, meta):
         if meta is None:
             return "value was null"
@@ -187,10 +196,6 @@ class Float(DataType):
     def doc(self):
         return "A float"
 
-    @classmethod
-    def schema(cls) -> Dict:
-        return {"type": "number", "required": True}
-
     def input_field_from_input(self, meta: Dict):
         return next(iter(meta.values()))
 
@@ -198,6 +203,12 @@ class Float(DataType):
         if meta is None:
             return self.optional or allow_null_if_not_optional
         return isinstance(meta, float) or isinstance(meta, int)
+
+    def coerce_value_if_possible(self, value):
+        try:
+            return float(value)
+        except:
+            raise Exception(f"Value '{value}' cannot be coerced to a float")
 
     def invalid_value_hint(self, meta):
         if meta is None:
@@ -251,17 +262,29 @@ class Boolean(DataType):
     def doc(self):
         return "A boolean"
 
-    @classmethod
-    def schema(cls) -> Dict:
-        return {"type": "boolean", "required": True}
-
     def input_field_from_input(self, meta):
         return next(iter(meta.values()))
 
     def validate_value(self, meta: Any, allow_null_if_not_optional: bool) -> bool:
         if meta is None:
             return self.optional or allow_null_if_not_optional
+
+        if isinstance(meta, str):
+            return meta.lower() == "true" or meta.lower() == "false"
+        if isinstance(meta, int):
+            return meta == 0 or meta == 1
+
         return isinstance(meta, bool)
+
+    def coerce_value_if_possible(self, value):
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() == "true"
+        if isinstance(value, int):
+            return value != 0
+
+        raise Exception(f"Value {value} could not be coerced to boolean type")
 
     def invalid_value_hint(self, meta):
         if meta is None:

--- a/janis_core/types/data_types.py
+++ b/janis_core/types/data_types.py
@@ -192,6 +192,9 @@ class DataType(ABC):
     def validate_value(self, meta: Any, allow_null_if_not_optional: bool) -> bool:
         pass
 
+    def coerce_value_if_possible(self, value):
+        return value
+
     @abstractmethod
     def invalid_value_hint(self, meta):
         pass


### PR DESCRIPTION
Fixes #16 

This was mainly a problem for arguments passed on command line, but I think it's useful to allow input value coercion (and then apply to this the inputs). Before, janis-assistant guesses the type of input you've provided based on a guess hierarchy and didn't know about the input types.

Most specs allow some form of type coercion (and though we don't support between steps yet), so we'll just apply this to the inputs.

There's a corresponding change in janis-assistant to use this functionality (https://github.com/PMCC-BioinformaticsCore/janis-assistant/pull/17).