### PR TITLE
Upgrade to CWL v1.2

### DIFF
--- a/janis_core/deps/__init__.py
+++ b/janis_core/deps/__init__.py
@@ -1,0 +1,2 @@
+import cwl_utils.parser_v1_2 as cwlgen
+import wdlgen

--- a/janis_core/tests/test_translation.py
+++ b/janis_core/tests/test_translation.py
@@ -241,11 +241,3 @@ class TestExportPath(unittest.TestCase):
 #         # new interpretation: can't skip because default
 #         self.assertEqual(False, can_skip)
 #         # self.assertEqual(True, can_skip)
-
-
-class TestInputsOverride(unittest.TestCase):
-    def test1(self):
-        from janis_bioinformatics.tools.common import IndexFasta
-
-        outs = IndexFasta().generate_inputs_override(with_resource_overrides=True)
-        print(outs)

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -790,6 +790,28 @@ class TestCWLNotNullOperator(unittest.TestCase):
         print(cwltool)
 
 
+class TestCWLWhen(unittest.TestCase):
+    def test_basic(self):
+        w = WorkflowBuilder("my_conditional_workflow")
+
+        w.input("inp", String(optional=True))
+
+        w.step(
+            "print_if_has_value",
+            TestTool(testtool=w.inp),
+            # only print if the input "inp" is defined.
+            when=IsDefined(w.inp),
+        )
+
+        w.output("out", source=w.print_if_has_value)
+
+        c = cwl.translate_step_node(w.print_if_has_value)
+
+        self.assertEqual("$((inputs.__when_inp != null))", c.when)
+        extra_input: cwlgen.WorkflowStepInput = c.in_[-1]
+        self.assertEqual("__when_inp", extra_input.id)
+
+
 cwl_testtool = """\
 #!/usr/bin/env cwl-runner
 class: CommandLineTool

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -16,7 +16,7 @@ from janis_core.tests.testtools import (
     OperatorResourcesTestTool,
 )
 
-import cwl_utils.parser_v1_0 as cwlgen
+import cwl_utils.parser_v1_2 as cwlgen
 
 import janis_core.translations.cwl as cwl
 from janis_core import (

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -16,7 +16,7 @@ from janis_core.tests.testtools import (
     OperatorResourcesTestTool,
 )
 
-import cwl_utils.parser_v1_2 as cwlgen
+from janis_core.deps import cwlgen
 
 import janis_core.translations.cwl as cwl
 from janis_core import (

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -828,6 +828,11 @@ baseCommand: echo
 arguments:
 - position: 0
   valueFrom: test:\\\\t:escaped:\\\\n:characters"
+
+hints:
+- class: ToolTimeLimit
+  timelimit: |-
+    $([inputs.runtime_seconds, 86400].filter(function (inner) { return inner != null })[0])
 id: TestTranslationtool
 """
 

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -55,12 +55,12 @@ class TestCwlTranslatorOverrides(unittest.TestCase):
 
     def test_stringify_WorkflowBuilder(self):
         cwlobj = cwlgen.Workflow(
-            id="wid", cwlVersion="v1.0", inputs={}, outputs={}, steps={}
+            id="wid", cwlVersion="v1.2", inputs={}, outputs={}, steps={}
         )
         expected = """\
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 
 inputs: {}
 
@@ -75,12 +75,12 @@ id: wid
 
     def test_stringify_tool(self):
         cwlobj = cwlgen.CommandLineTool(
-            id="tid", inputs={}, outputs={}, cwlVersion="v1.0"
+            id="tid", inputs={}, outputs={}, cwlVersion="v1.2"
         )
         expected = """\
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.0
+cwlVersion: v1.2
 
 inputs: {}
 
@@ -815,7 +815,7 @@ class TestCWLWhen(unittest.TestCase):
 cwl_testtool = """\
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.0
+cwlVersion: v1.2
 label: Tool for testing translation
 
 requirements:
@@ -862,7 +862,7 @@ id: TestTranslationtool
 cwl_multiinput = """\
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 
 requirements:
 - class: InlineJavascriptRequirement
@@ -891,7 +891,7 @@ id: test_add_single_to_array_edge
 cwl_stepinput = """\
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 label: 'TEST: WorkflowWithStepInputExpression'
 
 requirements:
@@ -932,7 +932,7 @@ id: TestWorkflowWithStepInputExpression
 cwl_arraystepinput = """\
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 
 requirements:
 - class: InlineJavascriptRequirement

--- a/janis_core/tests/test_translation_wdl.py
+++ b/janis_core/tests/test_translation_wdl.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import Optional
 
-import wdlgen
+from janis_core.deps import wdlgen
 from janis_core.types import UnionType
 
 import janis_core.translations.wdl as wdl

--- a/janis_core/translations/cwl.py
+++ b/janis_core/translations/cwl.py
@@ -1692,7 +1692,7 @@ def build_resource_override_maps_for_workflow(
                         id=tool_pre + "runtime_cpu", type="int?"
                     ),
                     cwlgen.CommandInputParameter(
-                        id=tool_pre + "runtime_disks", type="string?"
+                        id=tool_pre + "runtime_disks", type="int?"
                     ),
                     cwlgen.CommandInputParameter(
                         id=tool_pre + "runtime_seconds", type="int?"

--- a/janis_core/translations/cwl.py
+++ b/janis_core/translations/cwl.py
@@ -24,7 +24,7 @@ from io import StringIO
 from typing import List, Dict, Optional, Tuple
 from typing import Union
 
-import cwl_utils.parser_v1_0 as cwlgen
+import cwl_utils.parser_v1_2 as cwlgen
 import ruamel.yaml
 
 from janis_core.translationdeps.supportedtranslations import SupportedTranslation
@@ -905,7 +905,7 @@ def translate_workflow_input(inp: InputNode, inputsdict) -> cwlgen.InputParamete
     if isinstance(dt, Array):
         sf = dt.subtype().secondary_files()
 
-    return cwlgen.InputParameter(
+    return cwlgen.WorkflowInputParameter(
         id=inp.id(),
         default=default,
         secondaryFiles=sf,
@@ -1619,11 +1619,13 @@ def build_resource_override_maps_for_workflow(
             tool_pre = prefix + s.id() + "_"
             inputs.extend(
                 [
-                    cwlgen.InputParameter(
+                    cwlgen.CommandInputParameter(
                         id=tool_pre + "runtime_memory", type="float?"
                     ),
-                    cwlgen.InputParameter(id=tool_pre + "runtime_cpu", type="int?"),
-                    # cwlgen.InputParameter(tool_pre + "runtime_disks", type="string?"),
+                    cwlgen.CommandInputParameter(
+                        id=tool_pre + "runtime_cpu", type="int?"
+                    ),
+                    # cwlgen.CommandInputParameter(tool_pre + "runtime_disks", type="string?"),
                 ]
             )
         elif tool.type() == ToolType.Workflow:

--- a/janis_core/translations/cwl.py
+++ b/janis_core/translations/cwl.py
@@ -65,7 +65,7 @@ from janis_core.utils.logger import Logger
 from janis_core.utils.metadata import ToolMetadata
 from janis_core.workflow.workflow import StepNode, InputNode, OutputNode
 
-CWL_VERSION = "v1.0"
+CWL_VERSION = "v1.2"
 SHEBANG = "#!/usr/bin/env cwl-runner"
 yaml = ruamel.yaml.YAML()
 
@@ -1049,7 +1049,7 @@ def translate_tool_input(
 
 def translate_tool_argument(argument: ToolArgument, tool) -> cwlgen.CommandLineBinding:
     """
-    https://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineBinding
+    https://www.commonwl.org/v1.2/CommandLineTool.html#CommandLineBinding
 
     :param argument: Tool argument to build command line for
     :return:
@@ -1069,7 +1069,7 @@ def translate_tool_output(
     output: ToolOutput, inputsdict, tool, **debugkwargs
 ) -> cwlgen.CommandOutputParameter:
     """
-    https://www.commonwl.org/v1.0/CommandLineTool.html#CommandOutputParameter
+    https://www.commonwl.org/v1.2/CommandLineTool.html#CommandOutputParameter
 
     :param output:
     :type output: ToolOutput

--- a/janis_core/translations/cwl.py
+++ b/janis_core/translations/cwl.py
@@ -465,7 +465,8 @@ class CwlTranslator(TranslatorBase, metaclass=TranslatorMeta):
                 [
                     cwlgen.CommandInputParameter(id="runtime_memory", type="float?"),
                     cwlgen.CommandInputParameter(id="runtime_cpu", type="int?"),
-                    # cwlgen.CommandInputParameter("runtime_disks", type="string?"),
+                    cwlgen.CommandInputParameter(id="runtime_disks", type="int?"),
+                    cwlgen.CommandInputParameter(id="runtime_seconds", type="int?"),
                 ]
             )
 

--- a/janis_core/translations/cwl.py
+++ b/janis_core/translations/cwl.py
@@ -24,8 +24,9 @@ from io import StringIO
 from typing import List, Dict, Optional, Tuple
 from typing import Union
 
-import cwl_utils.parser_v1_2 as cwlgen
 import ruamel.yaml
+
+from janis_core.deps import cwlgen
 
 from janis_core.translationdeps.supportedtranslations import SupportedTranslation
 from janis_core.code.codetool import CodeTool
@@ -1375,7 +1376,7 @@ def add_when_conditional_for_workflow_stp(stp: cwlgen.WorkflowStep, when: Select
 def translate_step_node(
     step: StepNode,
     is_nested_tool=False,
-    resource_overrides: Dict[str, str] = None,
+    resource_overrides: Optional[Dict[str, str]] = None,
     use_run_ref=True,
     allow_empty_container=False,
     container_override=None,

--- a/janis_core/translations/wdl.py
+++ b/janis_core/translations/wdl.py
@@ -20,7 +20,7 @@ import json
 from inspect import isclass
 from typing import List, Dict, Any, Set, Tuple, Optional
 
-import wdlgen as wdl
+from janis_core.deps import wdlgen as wdl
 
 from janis_core.translationdeps.supportedtranslations import SupportedTranslation
 from janis_core.operators.logical import If, IsDefined

--- a/janis_core/types/common_data_types.py
+++ b/janis_core/types/common_data_types.py
@@ -4,7 +4,7 @@
 from inspect import isclass
 from typing import Union, Type, Dict, Any, Optional, List
 
-import cwl_utils.parser_v1_0 as cwlgen
+import cwl_utils.parser_v1_2 as cwlgen
 import wdlgen
 
 from janis_core.types.data_types import DataType, NativeTypes, NativeType, ParseableType

--- a/janis_core/types/common_data_types.py
+++ b/janis_core/types/common_data_types.py
@@ -4,9 +4,8 @@
 from inspect import isclass
 from typing import Dict, Any, Set
 
-import cwl_utils.parser_v1_2 as cwlgen
-import wdlgen
-from wdlgen import WdlType
+
+from janis_core.deps import cwlgen, wdlgen
 
 from janis_core.utils.logger import Logger
 from janis_core.__meta__ import GITHUB_URL
@@ -78,7 +77,7 @@ class UnionType(DataType):
             )
         return any(t.can_receive_from(other, *args, **kwargs) for t in self.subtypes)
 
-    def wdl(self, has_default=False) -> WdlType:
+    def wdl(self, has_default=False) -> wdlgen.WdlType:
         # custom stuff here
         wdl_data_types = [a.wdl() for a in self.subtypes]
         # we require the WDL to be identical for WDL to work

--- a/janis_core/types/data_types.py
+++ b/janis_core/types/data_types.py
@@ -14,7 +14,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Union, Type
 
-import cwl_utils.parser_v1_0 as cwlgen
+import cwl_utils.parser_v1_2 as cwlgen
 from wdlgen import WdlType
 
 from janis_core.utils import is_array_prefix

--- a/janis_core/types/data_types.py
+++ b/janis_core/types/data_types.py
@@ -14,8 +14,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Union, Type
 
-import cwl_utils.parser_v1_2 as cwlgen
-from wdlgen import WdlType
+from janis_core.deps import cwlgen, wdlgen
 
 from janis_core.utils import is_array_prefix
 from janis_core.utils.logger import Logger
@@ -115,7 +114,7 @@ class NativeTypes:
 
     @staticmethod
     def map_to_wdl(t: NativeType):
-        import wdlgen as wdl
+        from janis_core.deps import wdlgen as wdl
 
         if t == NativeTypes.kBool:
             return wdl.PrimitiveType.kBoolean
@@ -280,9 +279,9 @@ class DataType(ABC):
     def cwl_input(self, value: Any):
         return value
 
-    def wdl(self, has_default=False) -> WdlType:
+    def wdl(self, has_default=False) -> wdlgen.WdlType:
         qm = self._question_mark_if_optional(has_default)
-        return WdlType.parse_type(NativeTypes.map_to_wdl(self.primitive()) + qm)
+        return wdlgen.WdlType.parse_type(NativeTypes.map_to_wdl(self.primitive()) + qm)
 
     def parse_value(self, valuetoparse):
         """

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "tabulate",
         "path",
         "cwlformat >= 2020.5.19",
-        "cwl-utils >= 0.6",
+        "cwl-utils >= 0.7",
         "graphviz",
     ],
     # entry_points={"janis.extension": ["core=core"]},


### PR DESCRIPTION
With conditionals being released, it's time to upgrade Janis workflows to CWL v1.2. This shouldn't be a breaking change for workflows as there's no syntax change. It might break your engine if your engine doesn't correctly support CWL v1.2 - so it might be worth bumping Janis to v0.11.x.