### PR TITLE
Add WDL parser to Janis

### DIFF
--- a/janis_core/ingestion/fromwdl.py
+++ b/janis_core/ingestion/fromwdl.py
@@ -1,0 +1,387 @@
+import os
+import re
+from types import LambdaType
+from typing import List, Union, Optional, Callable
+import WDL
+
+import janis_core as j
+
+class WdlParser:
+    @staticmethod
+    def from_doc(doc: str, base_uri=None):
+        abs_path = os.path.relpath(doc)
+        d = WDL.load(abs_path)
+
+        parser = WdlParser()
+
+        if d.workflow:
+            return parser.from_loaded_object(d.workflow)
+
+        tasks = []
+        for t in d.tasks:
+            tasks.append(parser.from_loaded_object(t))
+
+        return tasks[0]
+
+    def from_loaded_object(self, obj: WDL.SourceNode):
+        if isinstance(obj, WDL.Task):
+            return self.from_loaded_task(obj)
+        elif isinstance(obj, WDL.Workflow):
+            return self.from_loaded_workflow(obj)
+
+    def from_loaded_workflow(self, obj: WDL.Workflow):
+        wf = j.WorkflowBuilder(identifier=obj.name)
+
+        for inp in obj.inputs:
+            self.add_decl_to_wf_input(wf, inp)
+
+        for call in obj.body:
+            self.add_call_to_wf(wf, call)
+
+        return wf
+
+    def workflow_selector_getter(self, wf, exp: str):
+        if "." in exp:
+            node, *tag = exp.split(".")
+            if len(tag) > 1:
+                raise Exception(f"Couldn't parse source ID: {exp} - too many '.'")
+            return wf[node][tag[0]]
+
+        return wf[exp]
+
+    def add_call_to_wf(
+        self, wf: j.WorkflowBase, call: WDL.WorkflowNode, condition=None, foreach=None, expr_alias: str=None
+    ):
+        def selector_getter(exp):
+            if exp == expr_alias:
+                return j.ForEachSelector()
+
+            return self.workflow_selector_getter(wf, exp)
+
+        if isinstance(call, WDL.Call):
+            task = self.from_loaded_object(call.callee)
+            inp_map = {}
+            for k, v in call.inputs.items():
+                new_expr = self.translate_expr(v, input_selector_getter=selector_getter)
+
+                inp_map[k] = new_expr
+
+
+            return wf.step(call.name, task(**inp_map), when=condition, _foreach=foreach)
+
+        elif isinstance(call, WDL.Conditional):
+            # if len(call.body) > 1:
+            #     raise NotImplementedError(
+            #         f"Janis can't currently support more than one call inside the conditional: {', '.join(str(c) for c in call.body)}")
+            for inner_call in call.body:
+                # inner_call = call.body[0]
+                self.add_call_to_wf(
+                    wf,
+                    inner_call,
+                    condition=self.translate_expr(
+                        call.expr, input_selector_getter=selector_getter
+                    ),
+                    expr_alias=expr_alias,
+
+                )
+        elif isinstance(call, WDL.Scatter):
+            # for scatter, we want to take the call.expr, and pass it to a step.foreach
+
+            foreach = self.translate_expr(call.expr)
+
+            scar_var_type = self.parse_wdl_type(call.expr.type)
+            if isinstance(scar_var_type, WDL.Type.Array):
+                scar_var_type = scar_var_type.item_type
+
+            # when we unwrap each step-input to the workflow, we want to replace 'call.variable' with
+            #       lambda el: <operation with call.variable substituted for {el}>
+            # if call.variable not in wf.input_nodes:
+            #     wf.input(call.variable, scar_var_type)
+            for inner_call in call.body:
+                self.add_call_to_wf(wf, inner_call, foreach=foreach, expr_alias=call.variable)
+
+        elif isinstance(call, WDL.Decl):
+            self.add_decl_to_wf_input(wf, call)
+        else:
+            raise NotImplementedError(f"body type: {type(call)}")
+
+    def add_decl_to_wf_input(self, wf: j.WorkflowBase, inp: WDL.Decl):
+        default = None
+        if inp.expr:
+            def selector_getter(exp):
+                return self.workflow_selector_getter(wf, exp)
+            default = self.translate_expr(inp.expr, input_selector_getter=selector_getter)
+
+        return wf.input(inp.name, self.parse_wdl_type(inp.type), default=default)
+
+    @classmethod
+    def container_from_runtime(cls, runtime, inputs: List[WDL.Decl]):
+        container = runtime.get("container", runtime.get("docker"))
+        if isinstance(container, WDL.Expr.Get):
+            # relevant input
+            inp = [i.expr for i in inputs if i.name == str(container.expr)]
+            if len(inp) > 0:
+                container = inp[0]
+            else:
+                j.Logger.warn(
+                    f"Expression for determining containers was '{container}' "
+                    f"but couldn't find input called {str(container.expr)}"
+                )
+        if isinstance(container, WDL.Expr.String):
+            container = container.literal
+        if isinstance(container, WDL.Value.String):
+            container = container.value
+        if container is None:
+            container = "ubuntu:latest"
+        if not isinstance(container, str):
+            j.Logger.warn(f"Expression for determining containers ({container}) are not supported in Janis, using ubuntu:latest")
+            container = "ubuntu:latest"
+        return container
+
+    def parse_memory_requirement(self, value):
+        s = self.translate_expr(value)
+        if isinstance(s, str):
+            if s.lower().endswith("gb"):
+                return float(s[:-2].strip())
+            elif s.lower().endswith("gib"):
+                return float(s[:-3].strip()) * 0.931323
+            elif s.lower().endswith("mb"):
+                return float(s[:-2].strip()) / 1000
+            elif s.lower().endswith("mib"):
+                return float(s[:-3].strip()) / 1024
+            raise Exception(f"Memory type {s}")
+        elif isinstance(s, (float, int)):
+            # in bytes?
+            return s / (1024**3)
+        elif isinstance(s, j.Selector):
+            return s
+        raise Exception(f"Couldn't recognise memory requirement '{value}'")
+
+    def parse_disk_requirement(self, value):
+        s = self.translate_expr(value)
+        if isinstance(s, str):
+            try:
+                return int(s)
+            except ValueError:
+                pass
+            pattern_matcher = re.match(r"local-disk (\d+) .*", s)
+            if not pattern_matcher:
+                raise Exception(f"Couldn't recognise disk type '{value}'")
+            s = pattern_matcher.groups()[0]
+            try:
+                return int(s)
+            except ValueError:
+                pass
+            if s.lower().endswith("gb"):
+                return float(s[:-2].strip())
+            elif s.lower().endswith("gib"):
+                return float(s[:-3].strip()) * 0.931323
+            elif s.lower().endswith("mb"):
+                return float(s[:-2].strip()) / 1000
+            elif s.lower().endswith("mib"):
+                return float(s[:-3].strip()) / 1024
+            raise Exception(f"Disk type type {s}")
+        elif isinstance(s, (float, int)):
+            # in bytes?
+            return s / (1024**3)
+        elif isinstance(s, j.Selector):
+            return s
+        raise Exception(f"Couldn't recognise memory requirement '{value}'")
+
+    def from_loaded_task(self, obj: WDL.Task):
+        rt = obj.runtime
+        translated_script = self.translate_expr(obj.command)
+        inputs = obj.inputs
+
+        cpus = self.translate_expr(rt.get("cpu"))
+        if cpus is not None and not isinstance(cpus, (int, float)):
+            cpus = int(cpus)
+
+        c = j.CommandToolBuilder(
+            tool=obj.name,
+            base_command=["sh", "script.sh"],
+            container=self.container_from_runtime(rt, inputs=inputs),
+            version="DEV",
+            inputs=[
+                self.parse_command_tool_input(i)
+                for i in obj.inputs
+                if not i.name.startswith("runtime_")
+            ],
+            outputs=[self.parse_command_tool_output(o) for o in obj.outputs],
+            files_to_create={"script.sh": translated_script},
+            memory=self.parse_memory_requirement(rt.get("memory")),
+            cpus=cpus,
+            disk=self.parse_disk_requirement(rt.get("disks"))
+        )
+
+        return c
+
+    def translate_expr(
+        self, expr: WDL.Expr.Base, input_selector_getter: Callable[[str], any] = None
+    ) -> Optional[Union[j.Selector, List[j.Selector], int, str, float, bool]]:
+        if expr is None:
+            return None
+
+        tp = lambda exp: self.translate_expr(
+            exp, input_selector_getter=input_selector_getter
+        )
+
+        if isinstance(expr, WDL.Expr.Array):
+            # a literal array
+            return [self.translate_expr(e) for e in expr.items]
+        if isinstance(expr, WDL.Expr.String):
+            return self.translate_wdl_string(expr)
+        elif isinstance(expr, (WDL.Expr.Int, WDL.Expr.Boolean, WDL.Expr.Float)):
+            return expr.literal.value
+        if isinstance(expr, WDL.Expr.Placeholder):
+            return self.translate_expr(expr.expr)
+        if isinstance(expr, WDL.Expr.IfThenElse):
+            return j.If(tp(expr.condition), tp(expr.consequent), tp(expr.alternative))
+        elif isinstance(expr, WDL.Expr.Get):
+            n = str(expr.expr)
+            if input_selector_getter:
+                return input_selector_getter(n)
+            return j.InputSelector(n)
+        elif isinstance(expr, WDL.Expr.Apply):
+            return self.translate_apply(expr, input_selector_getter=input_selector_getter)
+
+        raise Exception(f"Unsupported WDL expression type: {expr} ({type(expr)})")
+
+    def translate_wdl_string(self, s: WDL.Expr.String):
+        if s.literal is not None:
+            return str(s.literal).lstrip('"').rstrip('"')
+
+        elements = {}
+        counter = 1
+        _format = str(s).lstrip('"').rstrip('"')
+
+        for placeholder in s.children:
+            if isinstance(placeholder, (str, bool, int, float)):
+                continue
+
+            token = f"JANIS_WDL_TOKEN_{counter}"
+            if str(placeholder) not in _format:
+                # if the placeholder came up again
+                continue
+
+            _format = _format.replace(str(placeholder), f"{{{token}}}")
+            elements[token] = self.translate_expr(placeholder)
+            counter += 1
+
+        if len(elements) == 0:
+            return str(s)
+
+        _format.replace("\\n", "\n")
+
+        return j.StringFormatter(_format, **elements)
+
+    def file_size_operator(self, src, *args):
+        multiplier = None
+        if len(args) > 1:
+            f = args[1].lower()
+            multiplier_heirarchy = [
+                ("ki" in f, 1024),
+                ("k" in f, 1000),
+                ("mi" in f, 1.024),
+                ("gi" in f, 0.001024),
+                ("g" in f, 0.001),
+            ]
+            if not any(m[0] for m in multiplier_heirarchy):
+                j.Logger.warn(f"Couldn't determine prefix {f} for FileSizeOperator, defaulting to MB")
+            else:
+                multiplier = [m[1] for m in multiplier_heirarchy if m[0] is True][0]
+
+        if isinstance(src, list):
+            return multiplier * sum(j.FileSizeOperator(s) for s in src)
+
+        base = j.FileSizeOperator(src, *args)
+        if multiplier is not None and multiplier != 1:
+            return multiplier * base
+        return base
+
+    def translate_apply(
+        self, expr: WDL.Expr.Apply, **expr_kwargs
+    ) -> Union[j.Selector, List[j.Selector]]:
+
+        # special case for select_first of array with one element
+        if expr.function_name == "select_first" and len(expr.arguments) > 0:
+            inner = expr.arguments[0]
+            if isinstance(inner, WDL.Expr.Array) and len(inner.items) == 1:
+                return self.translate_expr(inner.items[0]).assert_not_null()
+
+        args = [self.translate_expr(e, **expr_kwargs) for e in expr.arguments]
+
+        fn_map = {
+            "_land": j.AndOperator,
+            "defined": j.IsDefined,
+            "select_first": j.FilterNullOperator,
+            "basename": j.BasenameOperator,
+            "length": j.LengthOperator,
+            "_gt": j.GtOperator,
+            "_gte": j.GteOperator,
+            "_lt": j.LtOperator,
+            "_lte": j.LteOperator,
+            "sep": j.JoinOperator,
+            "_add": j.AddOperator,
+            "_interpolation_add": j.AddOperator,
+            "stdout": j.Stdout,
+            "_mul": j.MultiplyOperator,
+            "_div": j.DivideOperator,
+            "glob": j.WildcardSelector,
+            "range": j.RangeOperator,
+            "_at": j.IndexOperator,
+            "_negate": j.NotOperator,
+            "_sub": j.SubtractOperator,
+            "write_lines": lambda exp: f"JANIS: write_lines({exp})",
+            "size": self.file_size_operator,
+            "ceil": j.CeilOperator,
+
+        }
+        fn = fn_map.get(expr.function_name)
+        if fn is None:
+            raise Exception(f"Unhandled WDL apply function_name: {expr.function_name}")
+        if isinstance(fn, LambdaType):
+            return fn(args)
+        return fn(*args)
+
+    def parse_wdl_type(self, t: WDL.Type.Base):
+        optional = t.optional
+        if isinstance(t, WDL.Type.Int):
+            return j.Int(optional=optional)
+        elif isinstance(t, WDL.Type.String):
+            return j.String(optional=optional)
+        elif isinstance(t, WDL.Type.Float):
+            return j.Float(optional=optional)
+        elif isinstance(t, WDL.Type.Boolean):
+            return j.Boolean(optional=optional)
+        elif isinstance(t, WDL.Type.File):
+            return j.File(optional=optional)
+        elif isinstance(t, WDL.Type.Directory):
+            return j.Directory(optional=optional)
+        elif isinstance(t, WDL.Type.Array):
+            return j.Array(self.parse_wdl_type(t.item_type), optional=optional)
+
+        raise Exception(f"Didn't handle WDL type conversion for '{t}' ({type(t)})")
+
+    def parse_command_tool_input(self, inp: WDL.Decl):
+        default = None
+        if inp.expr:
+            default = self.translate_expr(inp.expr)
+
+        # explicitly skip "runtime_*" inputs because they're from janis
+        if inp.name.startswith("runtime_"):
+            return None
+
+        return j.ToolInput(inp.name, self.parse_wdl_type(inp.type), default=default)
+
+    def parse_command_tool_output(self, outp: WDL.Decl):
+        sel = self.translate_expr(outp.expr)
+
+        return j.ToolOutput(outp.name, self.parse_wdl_type(outp.type), selector=sel)
+
+
+if __name__ == "__main__":
+    doc = "path/to/doc.wdl"
+    t = WdlParser.from_doc(doc)
+
+    t.translate("janis")

--- a/janis_core/ingestion/fromwdl.py
+++ b/janis_core/ingestion/fromwdl.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import functools
 import os
 import re
 from types import LambdaType
@@ -110,6 +110,7 @@ class WdlParser:
                         call.expr, input_selector_getter=selector_getter
                     ),
                     expr_alias=expr_alias,
+                    foreach=foreach
                 )
         elif isinstance(call, WDL.Scatter):
             # for scatter, we want to take the call.expr, and pass it to a step.foreach
@@ -380,11 +381,16 @@ class WdlParser:
             "_at": j.IndexOperator,
             "_negate": j.NotOperator,
             "_sub": j.SubtractOperator,
-            "write_lines": lambda exp: f"JANIS: write_lines({exp})",
             "size": self.file_size_operator,
             "ceil": j.CeilOperator,
             "select_all": j.FilterNullOperator,
-            "sub": j.ReplaceOperator
+            "sub": j.ReplaceOperator,
+            "round": j.RoundOperator,
+            "write_lines": lambda exp: f"JANIS: write_lines({exp})",
+            "read_tsv": lambda exp: f'JANIS: j.read_tsv({exp})',
+            "read_boolean": lambda exp: f'JANIS: j.read_boolean({exp})',
+            'read_lines': lambda exp: f'JANIS: j.read_lines({exp})',
+
         }
         fn = fn_map.get(expr.function_name)
         if fn is None:

--- a/janis_core/ingestion/fromwdl.py
+++ b/janis_core/ingestion/fromwdl.py
@@ -9,7 +9,27 @@ import WDL
 import janis_core as j
 
 
+def error_boundary(return_value=None):
+    def try_catch_translate_inner(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not WdlParser.allow_errors:
+                return func(*args, **kwargs)
+            else:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    j.Logger.log_ex(e)
+                    return return_value
+
+        return wrapper
+
+    return try_catch_translate_inner
+
 class WdlParser:
+
+    allow_errors = False
+
     @staticmethod
     def from_doc(doc: str, base_uri=None):
         abs_path = os.path.relpath(doc)
@@ -52,6 +72,7 @@ class WdlParser:
 
         return wf[exp]
 
+    @error_boundary()
     def add_call_to_wf(
         self,
         wf: j.WorkflowBase,

--- a/janis_core/ingestion/fromwdl.py
+++ b/janis_core/ingestion/fromwdl.py
@@ -436,8 +436,12 @@ class WdlParser:
 
 
 if __name__ == "__main__":
-    # doc = "path/to/doc.wdl"
-    doc = "/Users/michael.franklin/source/wdlz/cramqc.wdl"
-    t = WdlParser.from_doc(doc)
-    t.get_dot_plot(log_to_stdout=True)
-    t.translate("hail")
+    import sys
+    if len(sys.argv) != 2:
+        raise Exception("Expected 1 argument, the name of a CWL tool.")
+        
+    toolname = sys.argv[1]
+
+    tool = WdlParser.from_doc(toolname)
+
+    tool.translate("janis")

--- a/janis_core/operators/logical.py
+++ b/janis_core/operators/logical.py
@@ -183,8 +183,6 @@ class NotOperator(SingleValueOperator):
         arg = unwrap_operator(self.args[0])
         return f"not {arg}"
 
-
-
     # Two value operators
 
 

--- a/janis_core/operators/logical.py
+++ b/janis_core/operators/logical.py
@@ -53,6 +53,10 @@ class IsDefined(Operator, ABC):
     def evaluate(self, inputs):
         return self.evaluate_arg(self.args[0], inputs) is not None
 
+    def to_python(self, unwrap_operator, *args):
+        arg = unwrap_operator(self.args[0])
+        return f"{arg} is not None"
+
     def to_cwl(self, unwrap_operator, *args):
         arg = unwrap_operator(self.args[0])
         # 2 equals (!=) in javascript will coerce undefined to equal null
@@ -103,6 +107,10 @@ class If(Operator, ABC):
         cond, v1, v2 = [unwrap_operator(a) for a in self.args]
         return f"{cond} ? {v1} : {v2}"
 
+    def to_python(self, unwrap_operator, *args):
+        condition, iftrue, iffalse = [unwrap_operator(a) for a in self.args]
+        return f"({iftrue} if {condition} else {iffalse})"
+
 
 class AssertNotNull(Operator):
     @staticmethod
@@ -116,6 +124,9 @@ class AssertNotNull(Operator):
         result = self.evaluate_arg(self.args[0], inputs)
         assert result is not None
         return result
+
+    def to_python(self, unwrap_operator, *args):
+        return unwrap_operator(unwrap_operator(args[0]))
 
     def to_wdl(self, unwrap_operator, *args):
         arg = unwrap_operator(self.args[0])
@@ -168,6 +179,12 @@ class NotOperator(SingleValueOperator):
     def apply_to(value):
         return not value
 
+    def to_python(self, unwrap_operator, *args):
+        arg = unwrap_operator(self.args[0])
+        return f"not {arg}"
+
+
+
     # Two value operators
 
 
@@ -178,7 +195,7 @@ class AndOperator(TwoValueOperator):
 
     @staticmethod
     def symbol():
-        return "&&"
+        return "and"
 
     @staticmethod
     def wdl_symbol():
@@ -206,7 +223,7 @@ class OrOperator(TwoValueOperator):
 
     @staticmethod
     def symbol():
-        return "||"
+        return "or"
 
     @staticmethod
     def wdl_symbol():
@@ -559,6 +576,10 @@ class FloorOperator(Operator):
     def __repr__(self):
         return str(self)
 
+    def to_python(self, unwrap_operator, *args):
+        arg = unwrap_operator(self.args[0])
+        return f"math.floor({arg})"
+
     def to_wdl(self, unwrap_operator, *args):
         arg = unwrap_operator(self.args[0])
         return f"floor({arg})"
@@ -577,7 +598,7 @@ class FloorOperator(Operator):
 class CeilOperator(Operator):
     @staticmethod
     def friendly_signature():
-        return "Numeric, NumericType -> Int"
+        return "Numeric -> Int"
 
     def argtypes(self) -> List[DataType]:
         return [NumericType]
@@ -591,6 +612,10 @@ class CeilOperator(Operator):
 
     def __repr__(self):
         return str(self)
+
+    def to_python(self, unwrap_operator, *args):
+        arg = unwrap_operator(self.args[0])
+        return f"math.ceil({arg})"
 
     def to_wdl(self, unwrap_operator, *args):
         arg = unwrap_operator(self.args[0])
@@ -624,6 +649,10 @@ class RoundOperator(Operator):
 
     def __repr__(self):
         return str(self)
+
+    def to_python(self, unwrap_operator, *args):
+        arg = unwrap_operator(self.args[0])
+        return f"math.round({arg})"
 
     def to_wdl(self, unwrap_operator, *args):
         arg = unwrap_operator(self.args[0])

--- a/janis_core/operators/operator.py
+++ b/janis_core/operators/operator.py
@@ -182,6 +182,7 @@ class IndexOperator(Operator, ABC):
     def to_python(self, unwrap_operator, *args):
         base, index = [unwrap_operator(a) for a in self.args]
         return f"{base}[{index}]"
+
     def to_wdl(self, unwrap_operator, *args):
         base, index = [unwrap_operator(a) for a in self.args]
         return f"{base}[{index}]"
@@ -231,7 +232,6 @@ class SingleValueOperator(Operator, ABC):
 
     def to_python(self, unwrap_operator, *args):
         return f"{self.symbol()}({unwrap_operator(*args)})"
-
 
 
 class TwoValueOperator(Operator, ABC):

--- a/janis_core/operators/operator.py
+++ b/janis_core/operators/operator.py
@@ -134,6 +134,10 @@ class Operator(Selector):
     def to_cwl(self, unwrap_operator, *args):
         pass
 
+    @abstractmethod
+    def to_python(self, unwrap_operator, *args):
+        pass
+
     def to_string_formatter(self):
         import re
         from janis_core.operators.stringformatter import StringFormatter
@@ -158,7 +162,10 @@ class IndexOperator(Operator, ABC):
         return [Array(AnyType), Int]
 
     def returntype(self):
-        return self.args[0].returntype().subtype()
+        inner = get_instantiated_type(self.args[0].returntype())
+        if isinstance(inner, Array):
+            return inner.subtype()
+        return inner
 
     def __str__(self):
         base, index = self.args
@@ -172,6 +179,9 @@ class IndexOperator(Operator, ABC):
 
         return iterable[idx]
 
+    def to_python(self, unwrap_operator, *args):
+        base, index = [unwrap_operator(a) for a in self.args]
+        return f"{base}[{index}]"
     def to_wdl(self, unwrap_operator, *args):
         base, index = [unwrap_operator(a) for a in self.args]
         return f"{base}[{index}]"
@@ -219,6 +229,10 @@ class SingleValueOperator(Operator, ABC):
     def to_cwl(self, unwrap_operator, *args):
         return f"{self.cwl_symbol()}({unwrap_operator(*args)})"
 
+    def to_python(self, unwrap_operator, *args):
+        return f"{self.symbol()}({unwrap_operator(*args)})"
+
+
 
 class TwoValueOperator(Operator, ABC):
     @staticmethod
@@ -252,6 +266,10 @@ class TwoValueOperator(Operator, ABC):
     def to_cwl(self, unwrap_operator, *args):
         arg1, arg2 = [unwrap_operator(a) for a in self.args]
         return f"({arg1} {self.cwl_symbol()} {arg2})"
+
+    def to_python(self, unwrap_operator, *args):
+        arg1, arg2 = [unwrap_operator(a) for a in self.args]
+        return f"({arg1} {self.symbol()} {arg2})"
 
     def __str__(self):
         args = self.args

--- a/janis_core/operators/selectors.py
+++ b/janis_core/operators/selectors.py
@@ -308,6 +308,14 @@ class InputSelector(Selector):
 
         return StringFormatter(f"{{{self.input_to_select}}}", **kwarg)
 
+    def init_dictionary(self):
+        d = {"input_to_select": self.input_to_select}
+        if self.remove_file_extension is not None:
+            d["remove_file_extension"] = self.remove_file_extension
+        if not isinstance(self.type_hint, File):
+            d["type_hint"] = self.type_hint
+        return d
+
     def __str__(self):
         return "inputs." + self.input_to_select
 
@@ -411,6 +419,9 @@ class AliasSelector(Selector):
 
     def returntype(self) -> DataType:
         return self.data_type
+
+    def __repr__(self):
+        return f"({self.inner_selector} as {self.data_type})"
 
     def to_string_formatter(self):
         from janis_core.operators.stringformatter import StringFormatter

--- a/janis_core/operators/selectors.py
+++ b/janis_core/operators/selectors.py
@@ -413,7 +413,19 @@ class AliasSelector(Selector):
         return self.data_type
 
     def to_string_formatter(self):
-        return f"({self.inner_selector} as {self.data_type})"
+        from janis_core.operators.stringformatter import StringFormatter
+
+        return StringFormatter("{value}", value=self.inner_selector)
+
+
+class ForEachSelector(Selector):
+    def returntype(self) -> DataType:
+        return File()
+
+    def to_string_formatter(self):
+        from janis_core.operators.stringformatter import StringFormatter
+
+        return StringFormatter("{inp}", inp=self)
 
 
 class ResourceSelector(InputSelector):

--- a/janis_core/operators/selectors.py
+++ b/janis_core/operators/selectors.py
@@ -340,7 +340,7 @@ class InputNodeSelector(Selector):
     def returntype(self):
         out = first_value(self.input_node.outputs()).outtype
 
-        if self.input_node is not None:
+        if self.input_node is not None and self.input_node.default is not None:
             import copy
 
             out = copy.copy(out)
@@ -375,8 +375,14 @@ class StepOutputSelector(Selector):
     def returntype(self):
         retval = self.node.outputs()[self.tag].outtype
 
-        if hasattr(self.node, "scatter") and self.node.scatter:
+        if self.node.node_type != NodeType.STEP:
+            return retval
+
+        if hasattr(self.node, "scatter") and self.node.scatter is not None:
             retval = Array(retval)
+        elif hasattr(self.node, "foreach") and self.node.foreach is not None:
+            retval = Array(retval)
+
         return retval
 
     @staticmethod

--- a/janis_core/operators/selectors.py
+++ b/janis_core/operators/selectors.py
@@ -245,6 +245,10 @@ class Selector(ABC):
 
         return BasenameOperator(self)
 
+    def replace(self, pattern, replacement):
+        from .standard import ReplaceOperator
+        return ReplaceOperator(self, pattern, replacement)
+
     def file_size(self):
         from .standard import FileSizeOperator
 

--- a/janis_core/operators/standard.py
+++ b/janis_core/operators/standard.py
@@ -64,7 +64,6 @@ class ReadJsonOperator(Operator):
     def to_python(self, unwrap_operator, *args):
         raise NotImplementedError("Determine _safe_ one line solution for ReadContents")
 
-
     def to_wdl(self, unwrap_operator, *args):
         f = unwrap_operator(self.args[0])
         return f"read_json({f})"
@@ -346,6 +345,7 @@ class FileSizeOperator(Operator):
     """
     Returned in MB: Note that this does NOT include the reference files (yet)
     """
+
     def __new__(cls, *args, **kwargs):
         multiplier = None
         src, *otherargs = args
@@ -360,7 +360,9 @@ class FileSizeOperator(Operator):
                 ("g" in f, 0.001),
             ]
             if not any(m[0] for m in multiplier_heirarchy):
-                Logger.warn(f"Couldn't determine prefix {f} for FileSizeOperator, defaulting to MB")
+                Logger.warn(
+                    f"Couldn't determine prefix {f} for FileSizeOperator, defaulting to MB"
+                )
             else:
                 multiplier = [m[1] for m in multiplier_heirarchy if m[0] is True][0]
 

--- a/janis_core/operators/standard.py
+++ b/janis_core/operators/standard.py
@@ -142,7 +142,7 @@ class BasenameOperator(Operator):
 
     def to_wdl(self, unwrap_operator, *args):
         arg = unwrap_operator(args[0])
-        return f"basename({unwrap_operator(arg)})"
+        return f"basename({arg})"
 
     def to_cwl(self, unwrap_operator, *args):
         arg = unwrap_operator(

--- a/janis_core/operators/standard.py
+++ b/janis_core/operators/standard.py
@@ -13,7 +13,7 @@ from janis_core.types import (
 )
 
 from janis_core.types.common_data_types import String, Array, AnyType
-from janis_core.operators.operator import Operator
+from janis_core.operators.operator import Operator, InputSelector
 
 
 class ReadContents(Operator):
@@ -465,7 +465,17 @@ class FilterNullOperator(Operator):
         if isinstance(self.args[0], list):
             rettype = self.args[0][0].returntype()
         else:
-            rettype = self.args[0].returntype().subtype()
+            outer_rettype = get_instantiated_type(self.args[0].returntype())
+            if not isinstance(outer_rettype, Array):
+                # hmmm, this could be a bad input selector
+                rettype = outer_rettype
+                if not isinstance(self.args[0], InputSelector):
+                    Logger.warn(
+                        f'Expected return type of "{self.args[0]}" to be an array, '
+                        f'but found {outer_rettype}, will return this as a returntype.'
+                    )
+            else:
+                rettype = outer_rettype.subtype()
 
         rettype = copy(get_instantiated_type(rettype))
         rettype.optional = False

--- a/janis_core/operators/standard.py
+++ b/janis_core/operators/standard.py
@@ -495,6 +495,36 @@ class FilterNullOperator(Operator):
         return [i for i in iterable if i is not None]
 
 
+class ReplaceOperator(Operator):
+
+    @staticmethod
+    def friendly_signature():
+        return "Base: String, Pattern: String, Replacement: String -> String"
+
+    def argtypes(self) -> List[DataType]:
+        return [String(), String(), String()]
+
+    def evaluate(self, inputs):
+        base, pattern, replacement = [self.evaluate_arg(a, inputs) for a in self.args]
+        import re
+        return re.sub(pattern, replacement, base)
+
+    def to_wdl(self, unwrap_operator, *args):
+        base, pattern, replacement = [unwrap_operator(a) for a in self.args]
+        return f"sub({base}, {pattern}, {replacement})"
+
+    def to_cwl(self, unwrap_operator, *args):
+        base, pattern, replacement = [unwrap_operator(a) for a in self.args]
+        return f"{base}.replace(new RegExp({pattern}), {replacement})"
+
+    def to_python(self, unwrap_operator, *args):
+        base, pattern, replacement = [unwrap_operator(a) for a in self.args]
+        return f"re.sub({pattern}, {replacement}, {base})"
+
+    def returntype(self) -> DataType:
+        return String()
+
+
 # class Stdout(Operator):
 #     @staticmethod
 #     def friendly_signature():

--- a/janis_core/operators/stringformatter.py
+++ b/janis_core/operators/stringformatter.py
@@ -65,6 +65,20 @@ class StringFormatter(Operator):
     def to_wdl(self, unwrap_operator, *args):
         raise Exception("Don't use this method")
 
+    def to_python(self, unwrap_operator, *args):
+        # TO avoid format errors when unwrapping StringFormatter, we'll use the following dictionary
+        # that returns the key if it's missing:
+        class DefaultDictionary(dict):
+            def __missing__(self, key):
+                return "{{" + str(key) + "}}"
+
+        d = DefaultDictionary({
+            # keep in curly braces for the
+            str(k): f"{{{unwrap_operator(v)}}}"
+            for k, v in self.kwargs.items()
+        })
+        return self._format.format_map(d)
+
     def evaluate(self, inputs):
         resolvedvalues = {
             k: self.evaluate_arg(v, inputs) for k, v in self.kwargs.items()

--- a/janis_core/operators/stringformatter.py
+++ b/janis_core/operators/stringformatter.py
@@ -66,20 +66,10 @@ class StringFormatter(Operator):
         raise Exception("Don't use this method")
 
     def to_python(self, unwrap_operator, *args):
-        # TO avoid format errors when unwrapping StringFormatter, we'll use the following dictionary
-        # that returns the key if it's missing:
-        class DefaultDictionary(dict):
-            def __missing__(self, key):
-                return "{{" + str(key) + "}}"
-
-        d = DefaultDictionary(
-            {
-                # keep in curly braces for the
-                str(k): f"{{{unwrap_operator(v)}}}"
-                for k, v in self.kwargs.items()
-            }
-        )
-        return self._format.format_map(d)
+        f = self._format
+        for k, v in self.kwargs.items():
+            f = f.replace(f"{{{str(k)}}}", unwrap_operator(v))
+        return f
 
     def evaluate(self, inputs):
         resolvedvalues = {

--- a/janis_core/operators/stringformatter.py
+++ b/janis_core/operators/stringformatter.py
@@ -72,11 +72,13 @@ class StringFormatter(Operator):
             def __missing__(self, key):
                 return "{{" + str(key) + "}}"
 
-        d = DefaultDictionary({
-            # keep in curly braces for the
-            str(k): f"{{{unwrap_operator(v)}}}"
-            for k, v in self.kwargs.items()
-        })
+        d = DefaultDictionary(
+            {
+                # keep in curly braces for the
+                str(k): f"{{{unwrap_operator(v)}}}"
+                for k, v in self.kwargs.items()
+            }
+        )
         return self._format.format_map(d)
 
     def evaluate(self, inputs):

--- a/janis_core/tests/test_operators.py
+++ b/janis_core/tests/test_operators.py
@@ -22,15 +22,15 @@ class TestOperators(unittest.TestCase):
 class TestAndOperator(unittest.TestCase):
     def test_add_operator(self):
         op = AndOperator("cond1", "cond2")
-        self.assertEqual("(cond1 && cond2)", str(op))
+        self.assertEqual("(cond1 and cond2)", str(op))
 
     def test_nested_add_operator(self):
         op = AndOperator("cond1", AndOperator("cond2", "cond3"))
-        self.assertEqual("(cond1 && (cond2 && cond3))", str(op))
+        self.assertEqual("(cond1 and (cond2 and cond3))", str(op))
 
-    def test_and_to_operator(self):
+    def test_and_two_operator(self):
         op = AndOperator("cond1", "cond2").op_and("cond3")
-        self.assertEqual("((cond1 && cond2) && cond3)", str(op))
+        self.assertEqual("((cond1 and cond2) and cond3)", str(op))
 
 
 class TestAddOperator(unittest.TestCase):

--- a/janis_core/tests/test_translation_cwl.py
+++ b/janis_core/tests/test_translation_cwl.py
@@ -16,6 +16,7 @@ from janis_core.tests.testtools import (
     EchoTestTool,
     FilenameGeneratedTool,
     OperatorResourcesTestTool,
+    TestForEach,
 )
 
 from janis_core.deps import cwlgen
@@ -1018,6 +1019,17 @@ class TestCWLWhen(unittest.TestCase):
         self.assertEqual("$((inputs.__when_inp != null))", c.when)
         extra_input: cwlgen.WorkflowStepInput = c.in_[-1]
         self.assertEqual("__when_inp", extra_input.id)
+
+
+class TestForEachSelectors(unittest.TestCase):
+    def test_minimal(self):
+        tool = TestForEach()
+        # tool.translate("cwl", export_path="~/Desktop/tmp", to_disk=True)
+        w, _ = CwlTranslator.translate_workflow(tool)
+
+        stp = w.steps[0]
+        self.assertEqual("inp", stp.in_[0].source)
+        self.assertEqual('$((inputs._idx + "-hello"))', stp.in_[1].valueFrom)
 
 
 cwl_testtool = """\

--- a/janis_core/tests/test_translation_wdl.py
+++ b/janis_core/tests/test_translation_wdl.py
@@ -39,6 +39,7 @@ from janis_core.tests.testtools import (
     ArrayTestTool,
     OperatorResourcesTestTool,
     TestWorkflowThatOutputsArraysOfSecondaryFiles,
+    TestForEach,
 )
 from janis_core.translations import WdlTranslator
 from janis_core.utils.scatter import ScatterDescription, ScatterMethod
@@ -1595,6 +1596,32 @@ class TestUnionType(unittest.TestCase):
     def test_file_int_fail(self):
         uniontype = UnionType(File, int)
         self.assertRaises(Exception, uniontype.wdl)
+
+
+class TestForEachSelectors(unittest.TestCase):
+    def test_minimal(self):
+        TestForEach().translate("wdl", to_disk=True, export_path="~/Desktop/tmp")
+        w, _ = WdlTranslator.translate_workflow(TestForEach())
+        expected = """\
+version development
+
+import "tools/EchoTestTool_TEST.wdl" as E
+
+workflow TestForEach {
+  input {
+    Array[String] inp
+  }
+  scatter (idx in inp) {
+     call E.EchoTestTool as print {
+      input:
+        inp=(idx + "-hello")
+    }
+  }
+  output {
+    Array[File] out = print.out
+  }
+}"""
+        self.assertEqual(expected.strip(), w.get_string().strip())
 
 
 t = CommandToolBuilder(

--- a/janis_core/tests/testtools.py
+++ b/janis_core/tests/testtools.py
@@ -18,6 +18,7 @@ from janis_core import (
     InputDocumentation,
     InputQualityType,
     Workflow,
+    ForEachSelector,
 )
 
 
@@ -312,3 +313,18 @@ class TestWorkflowThatOutputsArraysOfSecondaryFiles(Workflow):
         )
 
         self.output("out", source=self.stp.out)
+
+
+class TestForEach(Workflow):
+    def constructor(self):
+        self.input("inp", Array(str))
+        self.step(
+            "print", EchoTestTool(inp=ForEachSelector() + "-hello"), _foreach=self.inp
+        )
+        self.output("out", source=self.print.out)
+
+    def friendly_name(self):
+        return self.id()
+
+    def id(self) -> str:
+        return "TestForEach"

--- a/janis_core/translations/translationbase.py
+++ b/janis_core/translations/translationbase.py
@@ -433,7 +433,8 @@ class TranslatorBase(ABC):
             values_provided_from_tool = {
                 i.id(): i.value or i.default
                 for i in tool.input_nodes.values()
-                if i.value is not None or (i.default is not None and not isinstance(i.default, Selector))
+                if i.value is not None
+                or (i.default is not None and not isinstance(i.default, Selector))
             }
 
         inp = {
@@ -500,10 +501,18 @@ class TranslatorBase(ABC):
                 seconds = max_duration
 
             return {
-                prefix + "runtime_memory": mem if not isinstance(mem, Selector) else None,
-                prefix + "runtime_cpu": cpus if not isinstance(cpus, Selector) else None,
-                prefix + "runtime_disks": disk if not isinstance(disk, Selector) else None,
-                prefix + "runtime_seconds": seconds if not isinstance(seconds, Selector) else None,
+                prefix + "runtime_memory": mem
+                if not isinstance(mem, Selector)
+                else None,
+                prefix + "runtime_cpu": cpus
+                if not isinstance(cpus, Selector)
+                else None,
+                prefix + "runtime_disks": disk
+                if not isinstance(disk, Selector)
+                else None,
+                prefix + "runtime_seconds": seconds
+                if not isinstance(seconds, Selector)
+                else None,
             }
 
         new_inputs = {}

--- a/janis_core/translations/translationbase.py
+++ b/janis_core/translations/translationbase.py
@@ -433,13 +433,13 @@ class TranslatorBase(ABC):
             values_provided_from_tool = {
                 i.id(): i.value or i.default
                 for i in tool.input_nodes.values()
-                if i.value or (i.default and not isinstance(i.default, Selector))
+                if i.value is not None or (i.default is not None and not isinstance(i.default, Selector))
             }
 
         inp = {
             i.id(): ad.get(i.id(), values_provided_from_tool.get(i.id()))
             for i in tool.tool_inputs()
-            if i.default is not None
+            if (i.default is not None and not isinstance(i.default, Selector))
             or not i.intype.optional
             or i.id() in ad
             or i.id() in values_provided_from_tool
@@ -479,20 +479,20 @@ class TranslatorBase(ABC):
             disk = inputs.get(f"{prefix}runtime_disks", 20)
             seconds = inputs.get(f"{prefix}runtime_seconds", 86400)
 
-            if max_cores and cpus > max_cores:
+            if max_cores is not None and cpus > max_cores:
                 Logger.info(
                     f"Tool '{tool.id()}' exceeded ({cpus}) max number of cores ({max_cores}), "
                     "this was dropped to the new maximum"
                 )
                 cpus = max_cores
-            if mem and max_mem and mem > max_mem:
+            if mem is not None and max_mem and mem > max_mem:
                 Logger.info(
                     f"Tool '{tool.id()}' exceeded ({mem} GB) max amount of memory ({max_mem} GB), "
                     "this was dropped to the new maximum"
                 )
                 mem = max_mem
 
-            if seconds and max_duration and seconds > max_duration:
+            if seconds is not None and max_duration and seconds > max_duration:
                 Logger.info(
                     f"Tool '{tool.id()}' exceeded ({seconds} secs) max duration in seconds ({max_duration} secs), "
                     "this was dropped to the new maximum"
@@ -500,10 +500,10 @@ class TranslatorBase(ABC):
                 seconds = max_duration
 
             return {
-                prefix + "runtime_memory": mem,
-                prefix + "runtime_cpu": cpus,
-                prefix + "runtime_disks": disk,
-                prefix + "runtime_seconds": seconds,
+                prefix + "runtime_memory": mem if not isinstance(mem, Selector) else None,
+                prefix + "runtime_cpu": cpus if not isinstance(cpus, Selector) else None,
+                prefix + "runtime_disks": disk if not isinstance(disk, Selector) else None,
+                prefix + "runtime_seconds": seconds if not isinstance(seconds, Selector) else None,
             }
 
         new_inputs = {}

--- a/janis_core/utils/bracketmatching.py
+++ b/janis_core/utils/bracketmatching.py
@@ -22,7 +22,7 @@ def get_keywords_between_braces(
     for i in range(len(text)):
 
         char = text[i]
-        if char == "{":
+        if char == "{" and (i < 0 or text[i-1] != "$"):
             counter += 1
             highest_level = max(highest_level, counter)
             if start_idx is None:

--- a/janis_core/workflow/workflow.py
+++ b/janis_core/workflow/workflow.py
@@ -122,12 +122,14 @@ class StepNode(Node):
         doc: DocumentationMeta = None,
         scatter: ScatterDescription = None,
         when: Operator = None,
+        _foreach=None
     ):
         super().__init__(wf, NodeType.STEP, identifier)
         self.tool = tool
         self.doc = doc
         self.scatter = scatter
         self.when = when
+        self.foreach = _foreach
 
         self.parent_has_conditionals = False
         self.has_conditionals = when is not None
@@ -679,6 +681,7 @@ class WorkflowBase(Tool):
         identifier: str,
         tool: Tool,
         scatter: Union[str, List[str], ScatterDescription] = None,
+        _foreach: Union[Selector, List[Selector]]=None,
         when: Optional[Operator] = None,
         ignore_missing=False,
         doc: str = None,
@@ -693,6 +696,10 @@ class WorkflowBase(Tool):
         :param when: An operator / condition that determines whether the step should run
         :type when: Optional[Operator]
         :param ignore_missing: Don't throw an error if required params are missing from this function
+        :param _foreach: NB: this is unimplemented. Iterate for each value of this resolves list, where
+                    you should use the "ForEachSelector" to select each value in this iterable.
+
+
         :return:
         """
 
@@ -711,6 +718,9 @@ class WorkflowBase(Tool):
                 )
 
             scatter = ScatterDescription(fields, method=ScatterMethod.dot)
+
+        if scatter is not None and _foreach is not None:
+            raise Exception(f"Can't supply 'scatter' and 'foreach' value to step with id: {identifier} for tool: {tool.id()}")
 
         # verify scatter
         if scatter:
@@ -756,7 +766,7 @@ class WorkflowBase(Tool):
 
         d = doc if isinstance(doc, DocumentationMeta) else DocumentationMeta(doc=doc)
         stp = StepNode(
-            self, identifier=identifier, tool=tool, scatter=scatter, when=when, doc=d
+            self, identifier=identifier, tool=tool, scatter=scatter, when=when, doc=d, _foreach=_foreach
         )
 
         added_edges = []


### PR DESCRIPTION
Adds:

- "foreach" which is similar to scatter. Perform some operation prior to scattering - this is the analogue to how WDL performs "scattering", and has greater flexibility for doing things like allowing you to iterate over a range of values.
   - this is implemented for CWL and WDL, and contains a small test.
- `to_python` for every operator. This isn't exactly useful for this PR (it will be for my future Hail Batch PR), but it was difficult to separate.


Known limitations:
- Doesn't support `structs`, maps, or objects
- Some methods don't have Janis equivalents (`read_*` and `write_*`, `cross`, `dot`)
- Not sure how it handles [expression placeholder options](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#expression-placeholder-options)
- Doesn't support nested scatters
- Setting variables in the call-space in workflow execution is not well supported.