### PR TITLE
Avoid creating file in user desktop, fix typos and tests location

### DIFF
--- a/janis_core/tests/test_translation_wdl.py
+++ b/janis_core/tests/test_translation_wdl.py
@@ -1,4 +1,5 @@
 import unittest
+from tempfile import TemporaryDirectory
 from typing import Optional
 
 from janis_core.deps import wdlgen
@@ -1600,7 +1601,8 @@ class TestUnionType(unittest.TestCase):
 
 class TestForEachSelectors(unittest.TestCase):
     def test_minimal(self):
-        TestForEach().translate("wdl", to_disk=True, export_path="~/Desktop/tmp")
+        with TemporaryDirectory() as tmpdir:
+            TestForEach().translate("wdl", to_disk=True, export_path=tmpdir)
         w, _ = WdlTranslator.translate_workflow(TestForEach())
         expected = """\
 version development

--- a/janis_core/translations/translationbase.py
+++ b/janis_core/translations/translationbase.py
@@ -64,7 +64,7 @@ class TranslatorMeta(type(ABC)):
 
 class TranslatorBase(ABC):
     """
-    So you're thinking about adding a new tWranslation :)
+    So you're thinking about adding a new translation :)
 
     This class will hopefully give you a pretty good indication
     on what's required to add a new translation, however what I
@@ -88,7 +88,7 @@ class TranslatorBase(ABC):
     and then write unit tests to cover each component of the translation
     and then an integration test of the whole translation on the related workflows.
 
-    You can find these in /janis/tests/test_translation_*.py)
+    You can find these in /janis_core/tests/test_translation_*.py)
     """
 
     __metaclass__ = TranslatorMeta

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,4 +1,4 @@
 -r base.txt
 Sphinx==1.8.2
 sphinx-autobuild==0.7.1
-tabulate==0.8.2
+tabulate


### PR DESCRIPTION
Issues found when trying to run a couple unit tests.

`translate_wdl` test was creating a folder on my `~/Desktop`, so I used `tempfile` instead.

And the `tabulate` was required otherwise installing `requirements/development.txt` fails as `base.txt` has unpinned `tabulate`, while `documentation.txt` has pinned `tabulate` (`pip` fails to resolve deps in this case).