### PR TITLE
ci: Fix Codecov upload and use new orb

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,5 +21,5 @@ jobs:
         pip install -r requirements/tests.txt
     - name: Test with pytest
       run: |
-        PYTHONPATH=. pytest janis_core/tests/test_*.py
-    - uses: codecov/codecov-action@v1
+        PYTHONPATH=. pytest --cov --cov-report xml janis_core/tests/test_*.py
+    - uses: codecov/codecov-action@v2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,5 @@
 -r base.txt
 nose
-codecov
 coverage
 requests_mock
-pytest
+pytest-cov


### PR DESCRIPTION
Tom from Codecov here. I noticed you weren't getting Codecov metrics anymore, so I made a few changes.
1. `pytest` wasn't producing coverage reports before, `pytest-cov` will do that.
2. Bumping to `v2` of the Codecov action

You can see the changes on my fork [here](https://github.com/thomasrockhu-codecov/janis-core/pull/1). Let me know if this helps! 